### PR TITLE
Update URLs to mod.audio

### DIFF
--- a/modcli/auth.py
+++ b/modcli/auth.py
@@ -33,7 +33,7 @@ def get_open_port():
 def login_sso_detached(api_url: str):
     click.echo('Running in detached mode...')
     click.echo(f'1) Open this url in any browser: {api_url}/users/tokens_sso')
-    click.echo('2) The URL will automatically redirect to MOD Forum (https://forum.moddevices.com)')
+    click.echo('2) The URL will automatically redirect to MOD Forum (https://forum.mod.audio)')
     click.echo('3) Once MOD Forum page loads, if asked, enter your credentials or register a new user')
     click.echo('4) A JWT token will be displayed in your browser')
     try:

--- a/modcli/cli.py
+++ b/modcli/cli.py
@@ -5,7 +5,7 @@ from importlib.metadata import version
 
 from modcli import context, auth, bundle
 
-_sso_disclaimer = '''SSO login requires you have a valid account in MOD Forum (https://forum.moddevices.com).
+_sso_disclaimer = '''SSO login requires you have a valid account in MOD Forum (https://forum.mod.audio).
 If your browser has an active session the credentials will be used for this login. Confirm?'''
 
 

--- a/modcli/settings.py
+++ b/modcli/settings.py
@@ -2,7 +2,7 @@ import os
 
 CONFIG_DIR = os.path.expanduser('~/.config/modcli')
 URLS = {
-    'labs': ('https://api-labs.moddevices.com/v2', 'https://pipeline-labs.moddevices.com/bundle/'),
-    'dev': ('https://api-dev.moddevices.com/v2', 'https://pipeline-dev.moddevices.com/bundle/'),
+    'labs': ('https://api-labs.mod.audio/v2', 'https://pipeline-labs.mod.audio/bundle/'),
+    'dev': ('https://api-dev.mod.audio/v2', 'https://pipeline-dev.mod.audio/bundle/'),
 }
 DEFAULT_ENV = 'labs'


### PR DESCRIPTION
Updates the MOD Forum, API, and pipeline URLs from `moddevices.com` to `mod.audio`.

- Forum URL in SSO login flow (`auth.py`, `cli.py`)
- API and pipeline endpoints for `labs` and `dev` environments (`settings.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)